### PR TITLE
Workarround for authentification errors

### DIFF
--- a/mailjet/connection.py
+++ b/mailjet/connection.py
@@ -19,6 +19,12 @@ class Connection(object):
                 self.access_key,
                 self.secret_key,
             )
+            password_mgr.add_password(
+                'Provide an apiKey and secretKey',
+                settings.URL,
+                self.access_key,
+                self.secret_key,
+            )
             # Create a handler for this password manager
             handler = urllib2.HTTPBasicAuthHandler(password_mgr)
             # Create an opener for the handler


### PR DESCRIPTION
On some function of some methods mailjet server answer with an 401 with a www-authenticate header set to 'Provide an apiKey and secretKey' so urllib2.HTTPPasswordMgrWithDefaultRealm didn't try to connect after getting a 401
