### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ Usage
     mailjet_api = mailjet.Api(api_key='YOUR_API_KEY', secret_key='YOUR_SECRET_KEY')
     account_info = mailjet_api.user.infos()
 
-``acount_info`` would now be assigned the following python dict:
+``account_info`` would now be assigned the following python dict:
 
 .. code:: py
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -273,7 +273,7 @@ epub_copyright = u'2012, Rick van Hattem'
 # The format is a list of tuples containing the path and title.
 #epub_pre_files = []
 
-# HTML files shat should be inserted after the pages created by sphinx.
+# HTML files that should be inserted after the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
 #epub_post_files = []
 

--- a/mailjet/settings.py
+++ b/mailjet/settings.py
@@ -13,7 +13,7 @@ variable. These settings can be overwritten by modifying the Django settings
 '''The timeout for the POST/GET requests'''
 # TIMEOUT = 10
 
-'''The API version, currently only 0.1 is suported'''
+'''The API version, currently only 0.1 is supported'''
 # VERSION = 0.1
 
 '''The url to fetch from, this is based on the version but this is not


### PR DESCRIPTION
There are small typos in:
- README.rst
- docs/conf.py
- mailjet/settings.py

Fixes:
- Should read `that` rather than `shat`.
- Should read `supported` rather than `suported`.
- Should read `account` rather than `acount`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md